### PR TITLE
Add planning documentation and kanban board for health app case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-Init
+# Kanban-plan for "Min Helseassistent"
+
+Denne repoen inneholder en enkel prosjektplan for caset "Min Helseassistent". Se `docs/PLAN.md` for:
+
+- Oppsummering av kravene i caset.
+- Fire hovedoppgaver (epics) som deler opp leveransen.
+- Et Kanban-oppsett for oppgaven "Helse- og symptomlogg" med tydelige verifikasjonskriterier.
+- Milepæler, avhengigheter og teststrategi.
+
+Planen kan importeres til et GitHub Project-board ved å legge hvert kort inn i tilsvarende kolonne.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,41 @@
+# Projektplan: Min Helseassistent
+
+## 1. Kravoppsummering
+- Helseapp for å holde oversikt over egen helse.
+- Brukeren skal kunne loggføre symptomer, måleverdier, søvn og humør.
+- Brukeren skal få oversikt over sine data gjennom grafer og rapporter.
+- Innebygde påminnelser og varslinger.
+- Tillegg (valgfritt): brukerinnlogging, deling, integrasjon mot eksterne API-er.
+
+## 2. Hovedleveranser (fire større oppgaver)
+1. **Grunnleggende prosjektoppsett**  
+   Oppsett av repository, utviklingsmiljø, CI, arkitektur og designskisser.
+2. **Helse- og symptomlogg**  
+   Skjema for registrering av symptomer, måleverdier, søvn og humør, med lokal lagring og validering.
+3. **Varsler og målsettinger**  
+   Modul for påminnelser, mål- og habit-tracking, samt konfigurering av push-varsler.
+4. **Dataanalyse og deling**  
+   Visualisering av data, rapporteksport, og frivillig funksjonalitet for deling/integrasjoner.
+
+## 3. Kanban for Oppgave 2: "Helse- og symptomlogg"
+
+| Kolonne | Kort | Beskrivelse | Test/Verifikasjon |
+| --- | --- | --- | --- |
+| **Backlog** | UX-LOGG-01 | Skisser registreringsflyt og skjemaer. | Wireframes signert av produktansvarlig. |
+| **Backlog** | DATA-LOGG-02 | Definer datamodell for helseoppføringer. | Enhetstester dekker feltvalidering. |
+| **Klar til å starte** | API-LOGG-03 | Avklar lagring (lokalt/sky) og API-kontrakter. | Godkjent teknisk design-notat. |
+| **I arbeid** | UI-LOGG-04 | Implementer skjerm for symptomregistrering med validering. | Manuell test: registrere og se oppsummering. |
+| **Under test** | TEST-LOGG-05 | Lag automatiserte tester (enhet + integrasjon). | Kommando `npm test logbook` passerer. |
+| **Utført** | DOC-LOGG-06 | Oppdater dokumentasjon og release-notat. | Pull request godkjent og merget. |
+
+## 4. Milepæler og avhengigheter
+- Oppgave 1 må ferdigstilles før Oppgave 2 kan starte (miljø og design må være klart).
+- Oppgave 2 og 3 kan kjøres parallelt etter at grunnoppsettet er klart.
+- Oppgave 4 avhenger av dataene fra Oppgave 2 for visualisering.
+
+## 5. Teststrategi
+- **Kontinuerlig integrasjon:** Kjør enhetstester på hver commit.
+- **Designgjennomganger:** Valider tidlig med interessenter.
+- **Brukertesting:** Korte brukerøkter for å verifisere registreringsflyten og varslingsfunksjonen.
+- **Måledata:** Test med både manuelle og automatiserte datasett for å sikre korrekte grafer.
+


### PR DESCRIPTION
## Summary
- document key requirements and four major workstreams for the "Min Helseassistent" case
- add a kanban table for the health and symptom log epic with verification criteria
- update the README to point to the detailed plan

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db99c08de88331a1dbf89b5ebd8355